### PR TITLE
add material transparency flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ cargo run -p wld-cli -- gfaydark.wld
 ```
 
 ## Acknowledgements
-This project wouldn't have been possible without Windcatcher's [WLD File Reference](https://eqemu.gitbook.io/server/categories/zones/customizing-zones/wld-file-reference).
+This project wouldn't have been possible without Windcatcher's [WLD File Reference](https://github.com/EQEmu/eqemu-docs-v2/blob/main/docs/server/zones/customizing-zones/wld-file-reference.md).
+
 Some documentation has been reproduced as comments within the parser module. Names of file
 fragments have been changed when another term from the [glTF reference](https://www.khronos.org/files/gltf20-reference-guide.pdf)
 seemed like a better fit. The goal is that this will be usable in more modern engines and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,10 @@
 ///!
 pub mod parser;
 
-use parser::{MaterialFragment, MeshFragment, MeshFragmentPolygonEntry, TextureFragment, WldDoc};
+use parser::{
+    MaterialFragment, MeshFragment, MeshFragmentPolygonEntry, TextureFragment, TransparencyFlags,
+    WldDoc,
+};
 use std::error::Error;
 
 pub struct WldError;
@@ -266,6 +269,10 @@ impl<'a> Material<'a> {
                 doc: self.doc,
                 fragment,
             })
+    }
+
+    pub fn transparency_flags(&self) -> &TransparencyFlags {
+        &self.fragment.transparency_flags
     }
 }
 

--- a/src/parser/fragments/material.rs
+++ b/src/parser/fragments/material.rs
@@ -168,7 +168,7 @@ mod tests {
 
         assert_eq!(frag.name_reference, StringReference::new(-22));
         assert_eq!(frag.flags, 0x02);
-        assert_eq!(frag.transparency_flags, 0x80000001);
+        assert_eq!(frag.transparency_flags.0, 0x80000001);
         assert_eq!(frag.params2, 0x4e4e4e);
         assert_eq!(frag.mask_color_coord, (0.0, 0.75));
         assert_eq!(frag.reference, FragmentRef::new(4));


### PR DESCRIPTION
I tried to match your style of dealing with flags.

The problem, however is that I'd like to still be able to check for potentially unknown flags.  For example there is a "stump bark" flag that has unknown purpose, and I'd like to be able to see that a material has that flag.  Any advice here?