### PR TITLE
add quick access to collision mesh

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,23 @@ impl<'a> Mesh<'a> {
             .collect()
     }
 
+    /// Vertices that should be part of the collision mesh
+    pub fn collision_indices(&self) -> Vec<u32> {
+        self.fragment
+            .polygons
+            .iter()
+            .filter(|p| 0x0010 & p.flags == 0)
+            .flat_map(|v| {
+                vec![
+                    v.vertex_indexes.0 as u32,
+                    v.vertex_indexes.1 as u32,
+                    v.vertex_indexes.2 as u32,
+                ]
+                .into_iter()
+            })
+            .collect()
+    }
+
     /// A list of materials used by this mesh.
     pub fn materials(&self) -> Vec<Material> {
         let material_list = self

--- a/src/parser/fragments/mesh.rs
+++ b/src/parser/fragments/mesh.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use super::{Fragment, FragmentRef, FragmentParser, MaterialListFragment, StringReference};
+use super::{Fragment, FragmentParser, FragmentRef, MaterialListFragment, StringReference};
 
 use nom::combinator::map;
 use nom::multi::count;
@@ -397,7 +397,7 @@ pub struct MeshFragmentPolygonEntry {
     /// Most flags are _Unknown_. This usually contains 0x0 for polygons but
     /// contains 0x0010 for polygons that the player can pass through (like water
     /// and tree leaves).
-    flags: u16,
+    pub flags: u16,
 
     /// An index for each of the polygon's vertex coordinates (idx1, idx2, idx3).
     pub vertex_indexes: (u16, u16, u16),


### PR DESCRIPTION
In using this library to generate meshes and collision meshes in a game engine, I found it useful to have quick access to all the indices of the mesh that should be present for collision.  In EQ I'm assuming collision was just calculated against the actual mesh, but in modern engines you generally have a separate mesh for collision.