### PR TITLE
Fix for PolygonAnimationFragment

### DIFF
--- a/src/parser/fragments/object_location.rs
+++ b/src/parser/fragments/object_location.rs
@@ -192,19 +192,19 @@ mod tests {
         let frag = ObjectLocationFragment::parse(data).unwrap().1;
 
         assert_eq!(frag.name_reference, StringReference::new(0));
-        assert_eq!(frag.flags, 0x1220);
-        assert_eq!(frag.fragment1, 46);
-        assert_eq!(frag.x, 0.000000000000000000000000000000000000000006503);
-        assert_eq!(frag.y, -2935.2515);
-        assert_eq!(frag.z, -2823.1519);
-        assert_eq!(frag.rotate_z, -19.758118);
+        assert_eq!(frag.flags, 0x2e);
+        assert_eq!(frag.fragment1, 4641);
+        assert_eq!(frag.x, -2935.2515);
+        assert_eq!(frag.y, -2823.1519);
+        assert_eq!(frag.z, -19.758118);
+        assert_eq!(frag.rotate_z, 0.0);
         assert_eq!(frag.rotate_y, 0.0);
         assert_eq!(frag.rotate_x, 0.0);
         assert_eq!(frag.params1, 0);
-        assert_eq!(frag.scale_y, 0.0);
+        assert_eq!(frag.scale_y, 0.5);
         assert_eq!(frag.scale_x, 0.5);
-        assert_eq!(frag.fragment2, 1056964608);
-        assert_eq!(frag.params2, Some(0));
+        assert_eq!(frag.fragment2, 0);
+        assert_eq!(frag.params2, None);
     }
 
     #[test]


### PR DESCRIPTION
Removed a "float" parameter (params1) from this frag as I think this may have been a typo in the WLD ref.  After removing it, this frag behaves as expected and fixes the crash when loading qeynos_obj.wld.

Fixes #9 