### PR TITLE
Small optimization for `EqArchive`

### DIFF
--- a/crates/libeq_archive/src/lib.rs
+++ b/crates/libeq_archive/src/lib.rs
@@ -52,11 +52,14 @@ impl EqArchive {
         let files = archive
             .filenames()
             .iter()
-            .map(|filename| {
+            .enumerate()
+            .map(|(position, filename)| {
                 Ok((
                     filename.to_owned(),
                     archive
-                        .get(filename)
+                        .index_entries
+                        .get(position)
+                        .map(|entry| entry.decompress(&archive.blocks))
                         .ok_or(Error::FileNotFound(filename.to_string()))?,
                 ))
             })
@@ -182,17 +185,6 @@ impl Archive {
         let (_, directory) =
             Directory::parse(&directory_data).expect("Failed to parse directory block");
         directory.filenames
-    }
-
-    fn get(&self, filename: &str) -> Option<Vec<u8>> {
-        self.filenames()
-            .iter()
-            .position(|f| f.eq_ignore_ascii_case(filename))
-            .and_then(|position| {
-                self.index_entries
-                    .get(position)
-                    .map(|entry| entry.decompress(&self.blocks))
-            })
     }
 }
 


### PR DESCRIPTION
I found a small inefficiency when looking at this file - `Archive.filenames()` was getting called for each item in the archive, which meant the directory was getting repeatedly decompressed.

Note that the method `Archive.get` which I eliminated was a bit confusing because it depended on `index_entries` being sorted to actually work correctly - and that sort was being done in the `read` method of `EqArchive`