### PR TITLE
libeq_wld: Support new-format (0x1000C800) WLD files

### DIFF
--- a/crates/libeq_wld/src/lib.rs
+++ b/crates/libeq_wld/src/lib.rs
@@ -43,7 +43,7 @@ pub mod parser;
 
 use parser::{
     Actor, ActorDef, DmSprite, DmSpriteDef2, DmSpriteDef2FaceEntry, DmTrackDef2, FragmentRef,
-    MaterialDef, RenderMethod, SimpleSpriteDef, SimpleSpriteDefFlags, WldDoc,
+    MaterialDef, RenderMethod, SimpleSpriteDef, SimpleSpriteDefFlags, TextureCoordinates, WldDoc,
 };
 use std::error::Error;
 
@@ -178,11 +178,13 @@ impl<'a> Mesh<'a> {
 
     /// The coordinates used to map textures to this mesh.
     pub fn texture_coordinates(&self) -> Vec<[f32; 2]> {
-        self.fragment
-            .texture_coordinates
-            .iter()
-            .map(|v| [(v.0 as f32) / 256.0, (v.1 as f32) / 256.0])
-            .collect()
+        match &self.fragment.texture_coordinates {
+            TextureCoordinates::Old(coords) => coords
+                .iter()
+                .map(|v| [(v.0 as f32) / 256.0, (v.1 as f32) / 256.0])
+                .collect(),
+            TextureCoordinates::New(coords) => coords.iter().map(|v| [v.0, v.1]).collect(),
+        }
     }
 
     /// Indices into the positions vector of this mesh. Expects that the mesh will be drawn as

--- a/crates/libeq_wld/src/parser/fragments/dm_sprite_def_2.rs
+++ b/crates/libeq_wld/src/parser/fragments/dm_sprite_def_2.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 
 use super::{
     DmTrack, Fragment, FragmentParser, FragmentRef, MaterialPalette, StringReference, WResult,
+    WldFormat,
 };
 
 use nom::Parser;
@@ -131,12 +132,9 @@ pub struct DmSpriteDef2 {
     /// be multiplied by (1 shl `scale`) for the final vertex position.
     pub positions: Vec<(i16, i16, i16)>,
 
-    /// Texture coordinates (x, y) used to map textures to this mesh.
-    ///
-    /// Two formats are possible:
-    /// * Old - Signed 16-bit texture value in pixels (most textures are 256 pixels in size).
-    /// * New - Signed 32-bit value
-    pub texture_coordinates: Vec<(i16, i16)>,
+    /// Texture coordinates (x, y) used to map textures to this mesh. The encoding
+    /// depends on the format of the containing .wld file.
+    pub texture_coordinates: TextureCoordinates,
 
     /// Vertex normals (x, y, z). Each element contains a signed byte representing the
     /// component of the vertex normal, scaled such that –127 represents –1 and
@@ -187,6 +185,42 @@ pub struct DmSpriteDef2 {
     pub meshops: Vec<DmSpriteDef2MeshOpEntry>,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq)]
+/// Texture coordinates (x, y) used to map textures to a [DmSpriteDef2].
+pub enum TextureCoordinates {
+    /// Old format - Signed 16-bit texture value in pixels (most textures are 256 pixels in size).
+    Old(Vec<(i16, i16)>),
+    /// New format - 32-bit floating point value.
+    New(Vec<(f32, f32)>),
+}
+
+impl TextureCoordinates {
+    fn parse(input: &[u8], entry_count: usize, format: WldFormat) -> WResult<'_, Self> {
+        match format {
+            WldFormat::Old => count((le_i16, le_i16), entry_count)
+                .parse(input)
+                .map(|(i, v)| (i, Self::Old(v))),
+            WldFormat::New => count((le_f32, le_f32), entry_count)
+                .parse(input)
+                .map(|(i, v)| (i, Self::New(v))),
+        }
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::Old(coords) => coords
+                .iter()
+                .flat_map(|t| [t.0.to_le_bytes(), t.1.to_le_bytes()].concat())
+                .collect(),
+            Self::New(coords) => coords
+                .iter()
+                .flat_map(|t| [t.0.to_le_bytes(), t.1.to_le_bytes()].concat())
+                .collect(),
+        }
+    }
+}
+
 impl FragmentParser for DmSpriteDef2 {
     type T = Self;
 
@@ -194,6 +228,14 @@ impl FragmentParser for DmSpriteDef2 {
     const TYPE_NAME: &'static str = "DmSpriteDef2";
 
     fn parse(input: &[u8]) -> WResult<'_, DmSpriteDef2> {
+        Self::parse_with_format(input, WldFormat::Old)
+    }
+}
+
+impl DmSpriteDef2 {
+    /// Parse with an explicit [WldFormat], which determines the encoding of
+    /// `texture_coordinates`. [FragmentParser::parse] assumes the old format.
+    pub fn parse_with_format(input: &[u8], format: WldFormat) -> WResult<'_, DmSpriteDef2> {
         let (
             i,
             (
@@ -259,7 +301,7 @@ impl FragmentParser for DmSpriteDef2 {
             ),
         ) = (
             count((le_i16, le_i16, le_i16), position_count as usize),
-            count((le_i16, le_i16), texture_coordinate_count as usize),
+            |i| TextureCoordinates::parse(i, texture_coordinate_count as usize, format),
             count((le_i8, le_i8, le_i8), normal_count as usize),
             count(le_u32, color_count as usize),
             count(DmSpriteDef2FaceEntry::parse, face_count as usize),
@@ -355,11 +397,7 @@ impl Fragment for DmSpriteDef2 {
                 .iter()
                 .flat_map(|p| [p.0.to_le_bytes(), p.1.to_le_bytes(), p.2.to_le_bytes()].concat())
                 .collect::<Vec<_>>()[..],
-            &self
-                .texture_coordinates
-                .iter()
-                .flat_map(|t| [t.0.to_le_bytes(), t.1.to_le_bytes()].concat())
-                .collect::<Vec<_>>()[..],
+            &self.texture_coordinates.to_bytes()[..],
             &self
                 .vertex_normals
                 .iter()
@@ -550,7 +588,7 @@ mod tests {
             meshop_count: 0,
             scale: 5,
             positions: vec![(2, -1154, -3), (100, 200, 300), (400, 500, 600)],
-            texture_coordinates: vec![(77, 77), (128, 0), (0, 128)],
+            texture_coordinates: TextureCoordinates::Old(vec![(77, 77), (128, 0), (0, 128)]),
             vertex_normals: vec![(29, 31, 119), (0, 0, 127), (0, 127, 0)],
             vertex_colors: vec![4043374848, 4043374848, 4043374848],
             faces: vec![DmSpriteDef2FaceEntry {
@@ -588,7 +626,7 @@ mod tests {
             meshop_count: 3,
             scale: 5,
             positions: vec![(0, 0, 0), (100, 0, 0), (0, 100, 0)],
-            texture_coordinates: vec![(0, 0), (128, 0), (0, 128)],
+            texture_coordinates: TextureCoordinates::Old(vec![(0, 0), (128, 0), (0, 128)]),
             vertex_normals: vec![(0, 0, 127), (0, 0, 127), (0, 0, 127)],
             vertex_colors: vec![],
             faces: vec![DmSpriteDef2FaceEntry {
@@ -652,8 +690,10 @@ mod tests {
         assert_eq!(frag.scale, 5);
         assert_eq!(frag.positions.len(), 3);
         assert_eq!(frag.positions[0], (2, -1154, -3));
-        assert_eq!(frag.texture_coordinates.len(), 3);
-        assert_eq!(frag.texture_coordinates[0], (77, 77));
+        assert_eq!(
+            frag.texture_coordinates,
+            TextureCoordinates::Old(vec![(77, 77), (128, 0), (0, 128)])
+        );
         assert_eq!(frag.vertex_normals.len(), 3);
         assert_eq!(frag.vertex_normals[0], (29, 31, 119));
         assert_eq!(frag.vertex_colors.len(), 3);
@@ -698,6 +738,25 @@ mod tests {
         let data = frag.to_bytes();
         let parsed = DmSpriteDef2::parse(&data).unwrap().1;
 
+        assert_eq!(parsed.to_bytes(), data);
+    }
+
+    #[test]
+    fn it_parses_new_format_texture_coordinates() {
+        let frag = DmSpriteDef2 {
+            texture_coordinates: TextureCoordinates::New(vec![
+                (0.8647, -0.5744),
+                (-0.0227, -0.5744),
+                (-0.0227, 0.2407),
+            ]),
+            ..fixture_basic()
+        };
+        let data = frag.to_bytes();
+
+        let parsed = DmSpriteDef2::parse_with_format(&data, WldFormat::New)
+            .unwrap()
+            .1;
+        assert_eq!(parsed, frag);
         assert_eq!(parsed.to_bytes(), data);
     }
 

--- a/crates/libeq_wld/src/parser/fragments/mod.rs
+++ b/crates/libeq_wld/src/parser/fragments/mod.rs
@@ -265,3 +265,13 @@ pub enum FragmentGame {
     Tanarus,
     ReturnToKrondor,
 }
+
+/// The two .wld file formats, distinguished by the version field in the file
+/// header. Some fragment layouts differ between them (see [DmSpriteDef2]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WldFormat {
+    /// Version `0x00015500`
+    Old,
+    /// Version `0x1000C800`, used for Luclin-and-later zone geometry.
+    New,
+}

--- a/crates/libeq_wld/src/parser/mod.rs
+++ b/crates/libeq_wld/src/parser/mod.rs
@@ -44,10 +44,11 @@ impl WldDoc {
             .parse(i)
             .map_err(|e| vec![e.into()])?;
 
+        let format = header.format();
         let (fragments, errors): (Vec<_>, Vec<_>) = fragment_headers
             .into_iter()
             .enumerate()
-            .map(|(idx, h)| h.parse_body(idx))
+            .map(|(idx, h)| h.parse_body(idx, format))
             .partition_map(|res| match res {
                 Ok(frag) => Either::Left(frag),
                 Err(e) => Either::Right(e),
@@ -229,6 +230,16 @@ pub struct WldHeader {
 }
 
 impl WldHeader {
+    /// Which format this file uses, determined by `version`. This mirrors the
+    /// client, which checks `version & 0xffff0000 == 0x10000000` for the new format.
+    pub fn format(&self) -> WldFormat {
+        if self.version & 0xffff0000 == 0x10000000 {
+            WldFormat::New
+        } else {
+            WldFormat::Old
+        }
+    }
+
     pub fn parse(input: &[u8]) -> WResult<'_, WldHeader> {
         let (i, magic) = le_u32(input)?;
         let (i, version) = le_u32(i)?;
@@ -315,7 +326,7 @@ impl<'a> FragmentHeader<'a> {
         ))
     }
 
-    fn parse_body(self, index: usize) -> Result<FragmentType, WldDocError<'a>> {
+    fn parse_body(self, index: usize, format: WldFormat) -> Result<FragmentType, WldDocError<'a>> {
         let parsed = match self.fragment_type {
             DmSpriteDef::TYPE_ID => match self.detect_0x2c_variant() {
                 FragmentGame::EverQuest => Some(
@@ -419,7 +430,7 @@ impl<'a> FragmentHeader<'a> {
                 Some(Region::parse(self.field_data).map(|f| (f.0, FragmentType::Region(f.1))))
             }
             DmSpriteDef2::TYPE_ID => Some(
-                DmSpriteDef2::parse(self.field_data)
+                DmSpriteDef2::parse_with_format(self.field_data, format)
                     .map(|f| (f.0, FragmentType::DmSpriteDef2(f.1))),
             ),
             MaterialPalette::TYPE_ID => Some(


### PR DESCRIPTION
Zone WLDs from Luclin onward use header version `0x1000C800`, which changes the encoding of `DmSpriteDef2` texture coordinates from 2x i16 to 2x f32. Reading them as i16 shifted every field after the coordinate block, so faces and material groups came out as garbage.

The format is now read from the file header, using the same check the client makes (`version & 0xffff0000 == 0x10000000`), and passed through to the fragment parser. `DmSpriteDef2::texture_coordinates` becomes an enum over the two encodings so a file still round-trips back to its original bytes. `Mesh::texture_coordinates` converts both to f32 as before, so callers see no difference.

Breaking change: `DmSpriteDef2::texture_coordinates` is now `TextureCoordinates::Old(Vec<(i16, i16)>)` or `New(Vec<(f32, f32)>)` rather than a plain `Vec<(i16, i16)>`, which also changes its serde representation.

Verified by parsing and re-serializing every WLD in a RoF2 install (1594 files across 1079 archives) with this branch and with `main`, and comparing the results. The 25 new-format zones now parse; output for the 1569 old-format files is byte for byte identical to `main`, including the 27 old-format `_obj` files that fail on both.
